### PR TITLE
Add extension log panel

### DIFF
--- a/src/main/kotlin/net/portswigger/mcp/ExtensionBase.kt
+++ b/src/main/kotlin/net/portswigger/mcp/ExtensionBase.kt
@@ -8,6 +8,7 @@ import net.portswigger.mcp.providers.ClaudeDesktopProvider
 import net.portswigger.mcp.providers.ManualProxyInstallerProvider
 import net.portswigger.mcp.providers.ProxyJarManager
 import net.portswigger.mcp.server.KtorServerManager
+import net.portswigger.mcp.logging.UiLogging
 
 @Suppress("unused")
 class ExtensionBase : BurpExtension {
@@ -15,15 +16,17 @@ class ExtensionBase : BurpExtension {
     override fun initialize(api: MontoyaApi) {
         api.extension().setName("Burp MCP Server")
 
-        val config = McpConfig(api.persistence().extensionData(), api.logging())
-        val serverManager = KtorServerManager(api)
+        val logging = UiLogging(api.logging())
 
-        val proxyJarManager = ProxyJarManager(api.logging())
+        val config = McpConfig(api.persistence().extensionData(), logging)
+        val serverManager = KtorServerManager(api, logging)
+
+        val proxyJarManager = ProxyJarManager(logging)
 
         val configUi = ConfigUi(
             config = config, providers = listOf(
-                ClaudeDesktopProvider(api.logging(), proxyJarManager),
-                ManualProxyInstallerProvider(api.logging(), proxyJarManager),
+                ClaudeDesktopProvider(logging, proxyJarManager),
+                ManualProxyInstallerProvider(logging, proxyJarManager),
             )
         )
 

--- a/src/main/kotlin/net/portswigger/mcp/KtorServerManager.kt
+++ b/src/main/kotlin/net/portswigger/mcp/KtorServerManager.kt
@@ -1,6 +1,7 @@
 package net.portswigger.mcp.server
 
 import burp.api.montoya.MontoyaApi
+import burp.api.montoya.logging.Logging
 import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
@@ -21,7 +22,7 @@ import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
-class KtorServerManager(private val api: MontoyaApi) : ServerManager {
+class KtorServerManager(private val api: MontoyaApi, private val logging: Logging) : ServerManager {
 
     private var server: EmbeddedServer<*, *>? = null
     private val executor: ExecutorService = Executors.newSingleThreadExecutor()
@@ -69,24 +70,24 @@ class KtorServerManager(private val api: MontoyaApi) : ServerManager {
 
                         if (origin != null) {
                             if (!isValidOrigin(origin)) {
-                                api.logging().logToOutput("Blocked DNS rebinding attack from origin: $origin")
+                                logging.logToOutput("Blocked DNS rebinding attack from origin: $origin")
                                 call.respond(HttpStatusCode.Forbidden)
                                 return@intercept
                             }
                         } else if (isBrowserRequest(userAgent)) {
-                            api.logging().logToOutput("Blocked browser request without Origin header")
+                            logging.logToOutput("Blocked browser request without Origin header")
                             call.respond(HttpStatusCode.Forbidden)
                             return@intercept
                         }
 
                         if (host != null && !isValidHost(host, config.port)) {
-                            api.logging().logToOutput("Blocked DNS rebinding attack from host: $host")
+                            logging.logToOutput("Blocked DNS rebinding attack from host: $host")
                             call.respond(HttpStatusCode.Forbidden)
                             return@intercept
                         }
 
                         if (referer != null && !isValidReferer(referer)) {
-                            api.logging().logToOutput("Blocked suspicious request from referer: $referer")
+                            logging.logToOutput("Blocked suspicious request from referer: $referer")
                             call.respond(HttpStatusCode.Forbidden)
                             return@intercept
                         }
@@ -101,16 +102,16 @@ class KtorServerManager(private val api: MontoyaApi) : ServerManager {
                         mcpServer
                     }
 
-                    mcpServer.registerTools(api, config)
+                    mcpServer.registerTools(api, config, logging)
                 }.apply {
                     start(wait = false)
                 }
 
-                api.logging().logToOutput("Started MCP server on ${config.host}:${config.port}")
+                logging.logToOutput("Started MCP server on ${config.host}:${config.port}")
                 callback(ServerState.Running)
 
             } catch (e: Exception) {
-                api.logging().logToError(e)
+                logging.logToError(e)
                 callback(ServerState.Failed(e))
             }
         }
@@ -123,10 +124,10 @@ class KtorServerManager(private val api: MontoyaApi) : ServerManager {
             try {
                 server?.stop(1000, 5000)
                 server = null
-                api.logging().logToOutput("Stopped MCP server")
+                logging.logToOutput("Stopped MCP server")
                 callback(ServerState.Stopped)
             } catch (e: Exception) {
-                api.logging().logToError(e)
+                logging.logToError(e)
                 callback(ServerState.Failed(e))
             }
         }

--- a/src/main/kotlin/net/portswigger/mcp/config/ConfigUi.kt
+++ b/src/main/kotlin/net/portswigger/mcp/config/ConfigUi.kt
@@ -49,6 +49,7 @@ class ConfigUi(private val config: McpConfig, private val providers: List<Provid
     private lateinit var advancedOptionsPanel: AdvancedOptionsPanel
     private lateinit var autoApproveTargetsPanel: AutoApproveTargetsPanel
     private lateinit var installationPanel: InstallationPanel
+    private lateinit var logPanel: LogPanel
 
     private var toggleListener: ((Boolean) -> Unit)? = null
     private var suppressToggleEvents: Boolean = false
@@ -77,6 +78,8 @@ class ConfigUi(private val config: McpConfig, private val providers: List<Provid
             config = config, providers = providers, reinstallNotice = reinstallNotice, parentComponent = panel
         )
 
+        logPanel = LogPanel()
+
         setupConfigListeners()
     }
 
@@ -96,6 +99,10 @@ class ConfigUi(private val config: McpConfig, private val providers: List<Provid
 
         if (::autoApproveTargetsPanel.isInitialized) {
             autoApproveTargetsPanel.cleanup()
+        }
+
+        if (::logPanel.isInitialized) {
+            logPanel.cleanup()
         }
     }
 
@@ -206,6 +213,8 @@ class ConfigUi(private val config: McpConfig, private val providers: List<Provid
         rightPanelContent.add(createVerticalStrut(10))
 
         rightPanelContent.add(installationPanel)
+        rightPanelContent.add(createVerticalStrut(Design.Spacing.LG))
+        rightPanelContent.add(logPanel)
 
         val columnsPanel = ResponsiveColumnsPanel(leftPanel, rightPanel)
         panel.add(columnsPanel, BorderLayout.CENTER)

--- a/src/main/kotlin/net/portswigger/mcp/config/components/LogPanel.kt
+++ b/src/main/kotlin/net/portswigger/mcp/config/components/LogPanel.kt
@@ -1,0 +1,73 @@
+package net.portswigger.mcp.config.components
+
+import net.portswigger.mcp.config.Design
+import net.portswigger.mcp.logging.ExtensionLogger
+import net.portswigger.mcp.logging.LogListenerHandle
+import java.awt.BorderLayout
+import javax.swing.*
+
+class LogPanel : JPanel() {
+    private val textArea = JTextArea().apply {
+        isEditable = false
+        lineWrap = true
+        wrapStyleWord = true
+        font = Design.Typography.bodyMedium
+    }
+    private var listenerHandle: LogListenerHandle? = null
+
+    init {
+        layout = BorderLayout()
+        updateColors()
+
+        val scrollPane = JScrollPane(textArea).apply {
+            border = null
+            verticalScrollBar.unitIncrement = 16
+        }
+
+        val container = JPanel().apply {
+            layout = BoxLayout(this, BoxLayout.Y_AXIS)
+            isOpaque = false
+            add(Design.createSectionLabel("MCP Activity Log"))
+            add(Box.createVerticalStrut(Design.Spacing.MD))
+            add(scrollPane)
+        }
+
+        add(container, BorderLayout.CENTER)
+
+        startListening()
+    }
+
+    override fun updateUI() {
+        super.updateUI()
+        updateColors()
+    }
+
+    private fun updateColors() {
+        background = Design.Colors.surface
+        border = BorderFactory.createCompoundBorder(
+            BorderFactory.createLineBorder(Design.Colors.outlineVariant, 1),
+            BorderFactory.createEmptyBorder(
+                Design.Spacing.MD,
+                Design.Spacing.MD,
+                Design.Spacing.MD,
+                Design.Spacing.MD
+            )
+        )
+    }
+
+    private fun startListening() {
+        textArea.text = ExtensionLogger.logs().joinToString("\n")
+        listenerHandle = ExtensionLogger.addListener { line ->
+            SwingUtilities.invokeLater {
+                if (textArea.text.isNotEmpty()) textArea.append("\n")
+                textArea.append(line)
+                textArea.caretPosition = textArea.document.length
+            }
+        }
+    }
+
+    fun cleanup() {
+        listenerHandle?.remove()
+        listenerHandle = null
+    }
+}

--- a/src/main/kotlin/net/portswigger/mcp/logging/ExtensionLogger.kt
+++ b/src/main/kotlin/net/portswigger/mcp/logging/ExtensionLogger.kt
@@ -1,0 +1,36 @@
+package net.portswigger.mcp.logging
+
+import java.lang.ref.WeakReference
+import java.util.concurrent.CopyOnWriteArrayList
+
+fun interface LogListenerHandle { fun remove() }
+
+object ExtensionLogger {
+    private val logs = CopyOnWriteArrayList<String>()
+    private val listeners = CopyOnWriteArrayList<WeakReference<(String) -> Unit>>()
+
+    fun log(message: String) {
+        logs.add(message)
+        val iterator = listeners.iterator()
+        while (iterator.hasNext()) {
+            val ref = iterator.next()
+            val listener = ref.get()
+            if (listener == null) {
+                listeners.remove(ref)
+            } else {
+                try {
+                    listener(message)
+                } catch (_: Exception) {
+                }
+            }
+        }
+    }
+
+    fun logs(): List<String> = logs.toList()
+
+    fun addListener(listener: (String) -> Unit): LogListenerHandle {
+        val ref = WeakReference(listener)
+        listeners.add(ref)
+        return LogListenerHandle { listeners.remove(ref) }
+    }
+}

--- a/src/main/kotlin/net/portswigger/mcp/logging/UiLogging.kt
+++ b/src/main/kotlin/net/portswigger/mcp/logging/UiLogging.kt
@@ -1,0 +1,20 @@
+package net.portswigger.mcp.logging
+
+import burp.api.montoya.logging.Logging
+
+class UiLogging(private val delegate: Logging) : Logging by delegate {
+    override fun logToOutput(message: String) {
+        delegate.logToOutput(message)
+        ExtensionLogger.log(message)
+    }
+
+    override fun logToError(message: String) {
+        delegate.logToError(message)
+        ExtensionLogger.log("ERROR: $message")
+    }
+
+    override fun logToError(throwable: Throwable) {
+        delegate.logToError(throwable)
+        ExtensionLogger.log("ERROR: ${throwable.message ?: throwable.javaClass.simpleName}")
+    }
+}

--- a/src/main/kotlin/net/portswigger/mcp/tools/Tools.kt
+++ b/src/main/kotlin/net/portswigger/mcp/tools/Tools.kt
@@ -9,6 +9,7 @@ import burp.api.montoya.http.HttpService
 import burp.api.montoya.http.message.HttpHeader
 import burp.api.montoya.http.message.requests.HttpRequest
 import io.modelcontextprotocol.kotlin.sdk.server.Server
+import burp.api.montoya.logging.Logging
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -22,14 +23,18 @@ import java.util.regex.Pattern
 import javax.swing.JTextArea
 
 private suspend fun checkHistoryPermissionOrDeny(
-    accessType: HistoryAccessType, config: McpConfig, api: MontoyaApi, logMessage: String
+    accessType: HistoryAccessType,
+    config: McpConfig,
+    api: MontoyaApi,
+    logMessage: String,
+    logging: Logging
 ): Boolean {
     val allowed = HistoryAccessSecurity.checkHistoryAccessPermission(accessType, config)
     if (!allowed) {
-        api.logging().logToOutput("MCP $logMessage access denied")
+        logging.logToOutput("MCP $logMessage access denied")
         return false
     }
-    api.logging().logToOutput("MCP $logMessage access granted")
+    logging.logToOutput("MCP $logMessage access granted")
     return true
 }
 
@@ -41,18 +46,19 @@ private fun truncateIfNeeded(serialized: String): String {
     }
 }
 
-fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
+
+fun Server.registerTools(api: MontoyaApi, config: McpConfig, logging: Logging) {
 
     mcpTool<SendHttp1Request>("Issues an HTTP/1.1 request and returns the response.") {
         val allowed = runBlocking {
             HttpRequestSecurity.checkHttpRequestPermission(targetHostname, targetPort, config, content, api)
         }
         if (!allowed) {
-            api.logging().logToOutput("MCP HTTP request denied: $targetHostname:$targetPort")
+            logging.logToOutput("MCP HTTP request denied: $targetHostname:$targetPort")
             return@mcpTool "Send HTTP request denied by Burp Suite"
         }
 
-        api.logging().logToOutput("MCP HTTP/1.1 request: $targetHostname:$targetPort")
+        logging.logToOutput("MCP HTTP/1.1 request: $targetHostname:$targetPort")
 
         val fixedContent = content.replace("\r", "").replace("\n", "\r\n")
 
@@ -81,11 +87,11 @@ fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
             HttpRequestSecurity.checkHttpRequestPermission(targetHostname, targetPort, config, http2RequestDisplay, api)
         }
         if (!allowed) {
-            api.logging().logToOutput("MCP HTTP request denied: $targetHostname:$targetPort")
+            logging.logToOutput("MCP HTTP request denied: $targetHostname:$targetPort")
             return@mcpTool "Send HTTP request denied by Burp Suite"
         }
 
-        api.logging().logToOutput("MCP HTTP/2 request: $targetHostname:$targetPort")
+        logging.logToOutput("MCP HTTP/2 request: $targetHostname:$targetPort")
 
         val orderedPseudoHeaderNames = listOf(":scheme", ":method", ":path", ":authority")
 
@@ -162,7 +168,7 @@ fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
 
     mcpTool<SetProjectOptions>("Sets project-level configuration in JSON format. This will be merged with existing configuration. Make sure to export before doing this, so you know what the schema is. Make sure the JSON has a top level 'user_options' object!") {
         if (config.configEditingTooling) {
-            api.logging().logToOutput("Setting project-level configuration: $json")
+            logging.logToOutput("Setting project-level configuration: $json")
             api.burpSuite().importProjectOptionsFromJson(json)
 
             "Project configuration has been applied"
@@ -174,7 +180,7 @@ fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
 
     mcpTool<SetUserOptions>("Sets user-level configuration in JSON format. This will be merged with existing configuration. Make sure to export before doing this, so you know what the schema is. Make sure the JSON has a top level 'project_options' object!") {
         if (config.configEditingTooling) {
-            api.logging().logToOutput("Setting user-level configuration: $json")
+            logging.logToOutput("Setting user-level configuration: $json")
             api.burpSuite().importUserOptionsFromJson(json)
 
             "User configuration has been applied"
@@ -191,7 +197,7 @@ fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
 
     mcpPaginatedTool<GetProxyHttpHistory>("Displays items within the proxy HTTP history") {
         val allowed = runBlocking {
-            checkHistoryPermissionOrDeny(HistoryAccessType.HTTP_HISTORY, config, api, "HTTP history")
+            checkHistoryPermissionOrDeny(HistoryAccessType.HTTP_HISTORY, config, api, "HTTP history", logging)
         }
         if (!allowed) {
             return@mcpPaginatedTool sequenceOf("HTTP history access denied by Burp Suite")
@@ -202,7 +208,7 @@ fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
 
     mcpPaginatedTool<GetProxyHttpHistoryRegex>("Displays items matching a specified regex within the proxy HTTP history") {
         val allowed = runBlocking {
-            checkHistoryPermissionOrDeny(HistoryAccessType.HTTP_HISTORY, config, api, "HTTP history")
+            checkHistoryPermissionOrDeny(HistoryAccessType.HTTP_HISTORY, config, api, "HTTP history", logging)
         }
         if (!allowed) {
             return@mcpPaginatedTool sequenceOf("HTTP history access denied by Burp Suite")
@@ -215,7 +221,7 @@ fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
 
     mcpPaginatedTool<GetProxyWebsocketHistory>("Displays items within the proxy WebSocket history") {
         val allowed = runBlocking {
-            checkHistoryPermissionOrDeny(HistoryAccessType.WEBSOCKET_HISTORY, config, api, "WebSocket history")
+            checkHistoryPermissionOrDeny(HistoryAccessType.WEBSOCKET_HISTORY, config, api, "WebSocket history", logging)
         }
         if (!allowed) {
             return@mcpPaginatedTool sequenceOf("WebSocket history access denied by Burp Suite")
@@ -227,7 +233,7 @@ fun Server.registerTools(api: MontoyaApi, config: McpConfig) {
 
     mcpPaginatedTool<GetProxyWebsocketHistoryRegex>("Displays items matching a specified regex within the proxy WebSocket history") {
         val allowed = runBlocking {
-            checkHistoryPermissionOrDeny(HistoryAccessType.WEBSOCKET_HISTORY, config, api, "WebSocket history")
+            checkHistoryPermissionOrDeny(HistoryAccessType.WEBSOCKET_HISTORY, config, api, "WebSocket history", logging)
         }
         if (!allowed) {
             return@mcpPaginatedTool sequenceOf("WebSocket history access denied by Burp Suite")

--- a/src/test/kotlin/net/portswigger/mcp/McpServerIntegrationTest.kt
+++ b/src/test/kotlin/net/portswigger/mcp/McpServerIntegrationTest.kt
@@ -18,7 +18,8 @@ import java.net.ServerSocket
 class McpServerIntegrationTest {
     private val client = TestSseMcpClient()
     private val api = mockk<MontoyaApi>(relaxed = true)
-    private val serverManager = KtorServerManager(api)
+    private val mockLogging = mockk<Logging>(relaxed = true)
+    private val serverManager = KtorServerManager(api, mockLogging)
     private val testPort = findAvailablePort()
     private val persistedObject = mockk<PersistedObject>()
     private var serverStarted = false
@@ -32,9 +33,9 @@ class McpServerIntegrationTest {
         every { persistedObject.setInteger(any(), any()) } returns Unit
     }
 
-    private val mockLogging = mockk<Logging>().apply {
-        every { logToError(any<String>()) } returns Unit
-        every { logToOutput(any<String>()) } returns Unit
+    init {
+        every { mockLogging.logToError(any<String>()) } returns Unit
+        every { mockLogging.logToOutput(any<String>()) } returns Unit
     }
 
     private val config = McpConfig(persistedObject, mockLogging)

--- a/src/test/kotlin/net/portswigger/mcp/tools/ToolsKtTest.kt
+++ b/src/test/kotlin/net/portswigger/mcp/tools/ToolsKtTest.kt
@@ -41,7 +41,8 @@ class ToolsKtTest {
     
     private val client = TestSseMcpClient()
     private val api = mockk<MontoyaApi>(relaxed = true)
-    private val serverManager = KtorServerManager(api)
+    private val mockLogging = mockk<Logging>(relaxed = true)
+    private val serverManager = KtorServerManager(api, mockLogging)
     private val testPort = findAvailablePort()
     private var serverStarted = false
     private val config: McpConfig
@@ -63,10 +64,8 @@ class ToolsKtTest {
             every { setString(any(), any()) } returns Unit
             every { setInteger(any(), any()) } returns Unit
         }
-        val mockLogging = mockk<Logging>().apply {
-            every { logToError(any<String>()) } returns Unit
-            every { logToOutput(any<String>()) } returns Unit
-        }
+        every { mockLogging.logToError(any<String>()) } returns Unit
+        every { mockLogging.logToOutput(any<String>()) } returns Unit
 
         config = McpConfig(persistedObject, mockLogging)
         


### PR DESCRIPTION
## Summary
- implement `ExtensionLogger` and `UiLogging` to collect log messages
- display activity log with new `LogPanel`
- wire logging into extension initialization and server manager
- update tools and tests for new logging

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6853babdd2748328ac531e1269bcb4ac